### PR TITLE
prevent UnboundLocalError for unasigned variable lang when switchLanguage is called without parameters

### DIFF
--- a/Products/PloneLanguageTool/skins/LanguageTool/switchLanguage.py
+++ b/Products/PloneLanguageTool/skins/LanguageTool/switchLanguage.py
@@ -8,18 +8,14 @@
 ##parameters=set_language=None
 REQUEST=context.REQUEST
 
-if set_language:
-    lang=set_language
-
 here_url=context.absolute_url()
 
 query = {}
-if lang:
-    # no cookie support
-    query['cl']=lang
-
 if set_language:
-    query['set_language']=lang
+    # no cookie support
+    query['cl']=set_language
+
+    query['set_language']=set_language
 
 qst="?"
 for k, v in query.items():


### PR DESCRIPTION
Open e.g. http://plone.org/switchLanguage  to see the error; it will result in a log entry like following:

2012-01-05T11:06:00 ERROR Zope.SiteErrorLog 1325757960.350.592968307284 http://www.WHATEVER.TH/E/URL/switchLanguage
Traceback (innermost last):
  Module ZPublisher.Publish, line 126, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 46, in call_object
  Module Products.CMFCore.FSPythonScript, line 130, in **call**
  Module Shared.DC.Scripts.Bindings, line 322, in **call**
  Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
  Module Products.PythonScripts.PythonScript, line 344, in _exec
  Module script, line 9, in switchLanguage
- <FSPythonScript at /XXX/switchLanguage used for /XXX/YYY/ZZZ>
- Line 9
  UnboundLocalError: local variable 'lang' referenced before assignment 
