### PR TITLE
Registered ILanguageTool interface by CMFCore.utils.registerToolInterface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 3.2.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Registered ILanguageTool interface to LanguageTool
+  by CMFCore.utils.registerToolInterface
+  [gborelli]
 
 
 3.2.6 (2012-12-09)
@@ -148,7 +150,7 @@ Changelog
   anything except the Plone site object itself.
   [hannosch]
 
-- In content negotiator, check for IContentish before looking up Language, 
+- In content negotiator, check for IContentish before looking up Language,
   otherwise chop off url parts and try again.
   [tesdal]
 
@@ -332,7 +334,7 @@ Changelog
 - Removed obsolete testSkeleton.
   [hannosch]
 
-- Changed the native Name of 'rm' to 'Rumantsch'. 
+- Changed the native Name of 'rm' to 'Rumantsch'.
   [jensens]
 
 1.4 - 2006-09-08

--- a/Products/PloneLanguageTool/LanguageTool.py
+++ b/Products/PloneLanguageTool/LanguageTool.py
@@ -23,6 +23,7 @@ from Products.CMFCore.permissions import ManagePortal
 from Products.CMFCore.permissions import View
 from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.utils import UniqueObject
+from Products.CMFCore.utils import registerToolInterface
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from Products.SiteAccess.VirtualHostMonster import VirtualHostMonster
 from ZODB.POSException import ConflictError
@@ -32,6 +33,7 @@ from ZPublisher.HTTPRequest import HTTPRequest
 from Products.PloneLanguageTool.interfaces import ILanguageTool
 from Products.PloneLanguageTool.interfaces import ITranslatable
 from Products.PloneLanguageTool.interfaces import INegotiateLanguage
+
 
 try:
     from Products.PlacelessTranslationService.Negotiator import registerLangPrefsMethod
@@ -69,7 +71,7 @@ class LanguageTool(UniqueObject, SimpleItem):
 
     # Used by functional tests.
     always_show_selector = 0
-    
+
     # resources that must not use language specific URLs
     exclude_paths = frozenset((
                      'portal_css',
@@ -386,8 +388,8 @@ class LanguageTool(UniqueObject, SimpleItem):
 
             # Now check if we need to exclude from using language specific path
             # See https://dev.plone.org/ticket/11263
-            if (bool([1 for p in self.exclude_paths if p in contentpath]) or 
-                bool([1 for p in self.exclude_exts if contentpath[0].endswith(p)]) 
+            if (bool([1 for p in self.exclude_paths if p in contentpath]) or
+                bool([1 for p in self.exclude_exts if contentpath[0].endswith(p)])
                 ):
                 return None
 
@@ -697,3 +699,5 @@ if _hasPTS:
     registerLangPrefsMethod({'klass':PrefsForPTS, 'priority':100 })
 
 InitializeClass(LanguageTool)
+registerToolInterface('portal_languages', ILanguageTool)
+

--- a/Products/PloneLanguageTool/tests/test_languagetool.py
+++ b/Products/PloneLanguageTool/tests/test_languagetool.py
@@ -1,7 +1,9 @@
 from zope.interface import alsoProvides
 from Products.CMFCore.interfaces import IDublinCore
+from Products.CMFCore.utils import getToolInterface
 
 from Products.PloneLanguageTool import LanguageTool
+from Products.PloneLanguageTool.interfaces import ILanguageTool
 from Products.PloneLanguageTool.tests import base
 
 
@@ -119,7 +121,11 @@ class TestLanguageTool(base.TestCase):
         self.ltool.REQUEST.path = ['foo.jpg', 'Members',]
         self.failUnless(self.ltool.getContentLanguage()==None)
         self.ltool.REQUEST.path = ['foo', 'portal_javascript',]
-        self.failUnless(self.ltool.getContentLanguage()==None)        
+        self.failUnless(self.ltool.getContentLanguage()==None)
+
+    def testRegisterInterface(self):
+        iface = getToolInterface('portal_languages')
+        self.assertEqual(iface, ILanguageTool)
 
 
 def test_suite():


### PR DESCRIPTION
Registering ILanguageTool interface allow us to use portal_languages tool 
like other Plone tools and register an utility to get it or to override the default one
